### PR TITLE
v0.0.4 - bulk-test 마커 일괄 제거

### DIFF
--- a/TEST_BULK_bugmade0916.md
+++ b/TEST_BULK_bugmade0916.md
@@ -1,9 +1,0 @@
-# Bulk Test Marker — bugmade0916
-
-- Repo: 05-IITP-DABT-Admin
-- Issue: #19
-- Account: bugmade0916
-- Round: 1
-- Created: 2026-04-29T10:26:10Z
-
-This file is a bulk token-validation marker. It will be removed by the cleanup PR.

--- a/TEST_BULK_minhe2.md
+++ b/TEST_BULK_minhe2.md
@@ -1,6 +1,0 @@
-# Bulk Test Marker — minhe2
-- Repo: 05-IITP-DABT-Admin
-- Issue: #23
-- Account: minhe2
-- Round: 3
-- Created: 2026-04-29T10:31:01Z

--- a/TEST_BULK_sweetk-chaesuhyeon.md
+++ b/TEST_BULK_sweetk-chaesuhyeon.md
@@ -1,6 +1,0 @@
-# Bulk Test Marker — sweetk-chaesuhyeon
-- Repo: 05-IITP-DABT-Admin
-- Issue: #21
-- Account: sweetk-chaesuhyeon
-- Round: 2
-- Created: 2026-04-29T10:28:47Z


### PR DESCRIPTION
Bulk token validation 종료. 모든 TEST_BULK_*.md 마커 제거.

Closes #25